### PR TITLE
Make conditions elegant

### DIFF
--- a/winspec.py
+++ b/winspec.py
@@ -142,9 +142,7 @@ class SpeFile(object):
             self._data = np.rollaxis(self._data, 2, 1)
 
             # flip data
-            if all([self.reversed == True, self.adc == '100 KHz']):
-                pass
-            elif any([self.reversed == True, self.adc == '100 KHz']):
+            if self.reversed == True ^ self.adc == '100 KHz':
                 self._data = self._data[:, ::-1, :]
                 log.debug('flipped data because of nonstandard ADC setting ' +\
                         'or reversed setting')


### PR DESCRIPTION
```
if all([a,b]):
    pass
elif any([a,b]):
    # do something
```

```
if (a^b):
    # do something
```

Results are identical